### PR TITLE
Fix indentation on line 28 of `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'file to push the changes to'
     required: false
     default: 'README.md'
-   section-name:
+  section-name:
     description: 'section name to add the table to in the file'
     required: false
     default: 'data-section'    


### PR DESCRIPTION
## Fixes Issue

Closes #43 

## Changes proposed

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

Error:
![image](https://github.com/EddieHubCommunity/gh-actions-html-table-generator/assets/3362854/119b2766-a817-476f-9e73-23b81b228ae7)

Success:
![image](https://github.com/EddieHubCommunity/gh-actions-html-table-generator/assets/3362854/797bcebd-a744-4a12-98e9-03879ffc7566)


## Note to reviewers

This bug was introduced by myself in #40 